### PR TITLE
Agregado de configuración para trabajar Eslint y Prettier correctamente

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,11 +1,10 @@
 {
-  "extends": ["airbnb-typescript/base"],
+  "extends": ["airbnb-typescript/base", "plugin:prettier/recommended"],
   "parserOptions": {
     "project": "./tsconfig.json"
   },
   "rules": {
-    "@typescript-eslint/comma-dangle": "off",
-    "implicit-arrow-linebreak": "off",
+    "prettier/prettier": "warn",
     "import/prefer-default-export": "off"
   }
 }


### PR DESCRIPTION
Se agregó una configuracion dentro del archivo de eslint para poder trabajar correctamente las configuraciones de Eslint y Prettier de la mano y no anden causando conflictos entre si.